### PR TITLE
[refactor] Crab 공격로직 수정

### DIFF
--- a/Assets/NaughtyAttributes/Scripts.meta
+++ b/Assets/NaughtyAttributes/Scripts.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 66686847ee1fa044bb15dfe473666178
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scenes/OpeningScene.unity
+++ b/Assets/Scenes/OpeningScene.unity
@@ -277,6 +277,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 676190207, guid: 627876c48b608564297925cbff008ae6, type: 3}
+      propertyPath: _gameSceneName
+      value: CrabTestScene
+      objectReference: {fileID: 0}
     - target: {fileID: 2571722715372187015, guid: 627876c48b608564297925cbff008ae6,
         type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Script/Entity/Enemy/Crab/Crab.cs
+++ b/Assets/Script/Entity/Enemy/Crab/Crab.cs
@@ -9,48 +9,19 @@ namespace NHD.Entity.Enemy.crab
 {
     public class Crab : SoundPlayableBase, IEnemy
     {
-        [SerializeField] private float ATTACK_DELAY_SEC = 3.0f;
         [SerializeField] private float REFLECT_POWER = 300.0f;
-        private EnemyState _state;
-        private bool _isAttackable;
         private Collider2D _collider;
-        private WaitForSeconds _attackDelay;
         private Transform _player;
 
         void Start()
         {
-            _isAttackable = true;
             _collider = GetComponent<Collider2D>();
-            _attackDelay = new WaitForSeconds(ATTACK_DELAY_SEC);
-        }
-
-        void Update()
-        {
-            CheckAttackable();
-        }
-
-        public void CheckAttackable()
-        {
-            if (_state == EnemyState.ATTACK && _isAttackable)
-            {
-                Attack();
-            }
         }
 
         public void Attack()
         {
-            _isAttackable = false;
-            StartCoroutine(AttackCoroutine());
-        }
-
-        IEnumerator AttackCoroutine()
-        {
             SoundManager._instance.PlayEFXAtPoint(_audioClips[0], transform.position);
             _player.GetComponent<PlayerCollider>().TriggerPlayerStunEvent(true, _collider.bounds.center, REFLECT_POWER);
-
-            yield return _attackDelay;
-
-            _isAttackable = true;
         }
 
         public void Move() { }
@@ -60,18 +31,8 @@ namespace NHD.Entity.Enemy.crab
             if (collision.CompareTag("Player"))
             {
                 _player = collision.transform;
-                _state = EnemyState.ATTACK;
+                Attack();
             }
         }
-
-        private void OnTriggerExit2D(Collider2D collision)
-        {
-            if (collision.CompareTag("Player"))
-            {
-                _player = null;
-                _state = EnemyState.IDLE;
-            }
-        }
-
     }
 }

--- a/Assets/Script/Entity/Enemy/Crab/Crab.cs
+++ b/Assets/Script/Entity/Enemy/Crab/Crab.cs
@@ -10,18 +10,31 @@ namespace NHD.Entity.Enemy.crab
     public class Crab : SoundPlayableBase, IEnemy
     {
         [SerializeField] private float REFLECT_POWER = 300.0f;
+        [SerializeField] private float ATTACK_DELAY = 5.0f;
+        private bool _isAttackable;
         private Collider2D _collider;
         private Transform _player;
+        private WaitForSeconds _attackDelay;
 
         void Start()
         {
+            _isAttackable = true;
             _collider = GetComponent<Collider2D>();
+            _attackDelay = new WaitForSeconds(ATTACK_DELAY);
         }
 
         public void Attack()
         {
             SoundManager._instance.PlayEFXAtPoint(_audioClips[0], transform.position);
             _player.GetComponent<PlayerCollider>().TriggerPlayerStunEvent(true, _collider.bounds.center, REFLECT_POWER);
+        }
+
+        IEnumerator AttackCoroutine()
+        {
+            _isAttackable = false;
+            Attack();
+            yield return _attackDelay;
+            _isAttackable = true;
         }
 
         public void Move() { }
@@ -31,7 +44,10 @@ namespace NHD.Entity.Enemy.crab
             if (collision.CompareTag("Player"))
             {
                 _player = collision.transform;
-                Attack();
+                if(_isAttackable)
+                {
+                    StartCoroutine(AttackCoroutine());
+                }
             }
         }
     }

--- a/Assets/Sounds/BGM.meta
+++ b/Assets/Sounds/BGM.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0c65ae1d3825be54183d00217e1178dd
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/StreamingAssets/StaticData/PaperData/STATIC_PAPER_DATA_ENG.json
+++ b/Assets/StreamingAssets/StaticData/PaperData/STATIC_PAPER_DATA_ENG.json
@@ -3,8 +3,8 @@
 	[
 		{
 			"_imagePath":"Sprites/Paper/DummyPaperIcon",
-			"_title":"The sorrows of the exam students 1",
-			"_description":"Imoogi begin their tests in the cave for the first time; On average, it takes more than 100 days to get out of the cave. The Imoogi who escaped from the cave said their experience whether they almost became humans by eating mugwort and garlic."
+			"_title":"The sorrows of the exam Imoogis 1",
+			"_description":"The Imoogi begins their tests in the cave for the first time; On average, it takes more than 100 days to get out of the cave. The Imoogi who escaped from the cave said their experience whether they almost became humans by eating mugwort and garlic."
 		},
 		{
 			"_imagePath":"Sprites/Paper/DummyPaperIcon",
@@ -13,13 +13,13 @@
 		},
 		{
 			"_imagePath":"Sprites/Paper/DummyPaperIcon",
-			"_title":"Hobbies of students",
-			"_description":"Imoogi learn some skills in advance to prepare food or to manage stress. One of the most popular pastimes is fishing. This is because you can shake off the clutter in your head while fishing. Similarly, It is said that picking up the excrement is the best way to express anger."
+			"_title":"Hobbies of Imoogis",
+			"_description":"The Imoogi learns some skills in advance to prepare food or to manage stress. One of the most popular pastimes is fishing. This is because the Imoogi can shake off the clutter in their head while fishing. Similarly, It is said that picking up the excrement is the best way to express anger."
 		},
 		{
 			"_imagePath":"Sprites/Paper/DummyPaperIcon",
-			"_title":"The sorrows of the exam students 2",
-			"_description":"The Imoogi must manage their stamina throughout the exam period by themselves. If you want to get into the first-come-first-served basis until you climb Yongoreum while soothing Yeouiju, you need to replenish your energy in between. Delaying sleep is not the solution."
+			"_title":"The sorrows of the exam Imoogis 2",
+			"_description":"The Imoogi must manage their stamina throughout the exam period by themselves. If Imoogi wants to get into the first-come-first-served basis until Imoogi climbs Yongoreum while soothing Yeouiju, you need to replenish your energy in between. Delaying sleep is not the solution."
 		},
 		{
 			"_imagePath":"Sprites/Paper/DummyPaperIcon",
@@ -53,13 +53,13 @@
 		},
 		{
 			"_imagePath":"Sprites/Paper/DummyPaperIcon",
-			"_title":" The relationship between Yeoui-ju and Lee Moo-gi 1",
-			"_description":"Before being hired, Lee Moo-gi meets at least two Yeoui-ju. The first is to prepare for the past exam, and it is characterized by a strong relationship between Yeouiju and Imoogi. However, the new Yeouiju she meets in Gyeongju has to build a relationship from the first."
+			"_title":" The relationship between Yeouiju and Imoogi 1",
+			"_description":"Before being hired, Imoogi meets at least two Yeouiju. The first is to prepare for the past exam, and it is characterized by a strong relationship between Yeouiju and Imoogi. However, the new Yeouiju she meets in Gyeongju has to build a relationship from the first."
 		},
 		{
 			"_imagePath":"Sprites/Paper/DummyPaperIcon",
-			"_title":"The relationship between Yeoui-ju and Lee Moo-gi 2",
-			"_description":"Therefore, dealing with the free-spirited Yeouiju is a test. Normally, Imoogi has to overwhelm Yeouiju with high magical power, but in the opposite case, he is dragged and failed the test. If you can't deal with Yeouiju, it's better to prepare for 1000 years again."
+			"_title":"The relationship between Yeouiju and Imoogi 2",
+			"_description":"Therefore, dealing with the free-spirited Yeouiju is a test. Normally, Imoogi has to overwhelm Yeouiju with high magical power, but in the opposite case, some Imoogis dragged and failed the test. If you can't deal with Yeouiju, it's better to prepare for 1000 years again."
 		},
 		{
 			"_imagePath":"Sprites/Paper/DummyPaperIcon",


### PR DESCRIPTION
# Crab 공격로직 수정
* ~~넉백돼서 기절하면 결국 공격 딜레이 동안은 게한테 닿을 일이 애초에 없음~~
    * ~~그런 이유로 공격 쿨타임 관련 로직 삭제~~
* 복잡한 State 필요없이 그냥 Collider 충돌만 확인되면 바로 넉백시키도록 수정